### PR TITLE
add kv1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ fn load_config() -> Result<Config, ConfigError> {
         "hvs.EXAMPLE_TOKEN".to_string(),      // Vault token
         "secret".to_string(),                 // KV mount name
         "dev".to_string(),        // Secret path
-        KvVersion::V2, // KV Version
     );
+
+    vault_source.set_kv_version(KvVersion::V1); // change kv_version to KV1 if required
 
     // Build configuration incorporating Vault and other sources
     Config::builder()
@@ -64,7 +65,7 @@ For more information, check the [complete documentation](https://docs.rs/config-
 ## Requirements
 
 - Rust 1.60 or higher
-- An accessible HashiCorp Vault server or compatible like https://github.com/Tongsuo-Project/RustyVault
+- An accessible HashiCorp Vault server or compatible like [RustyVault](https://github.com/Tongsuo-Project/RustyVault)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An extension for the `config` crate that allows loading configurations from Hash
 ## Features
 
 - Integration with the `config` crate through a custom `VaultSource`
-- Support for HashiCorp Vault's KV2 engine
+- Support for HashiCorp Vault's KV1 & KV2 engine
 - Secure loading of secrets through Vault's REST API
 
 ## Installation
@@ -34,6 +34,7 @@ fn load_config() -> Result<Config, ConfigError> {
         "hvs.EXAMPLE_TOKEN".to_string(),      // Vault token
         "secret".to_string(),                 // KV mount name
         "dev".to_string(),        // Secret path
+        KvVersion::V2, // KV Version
     );
 
     // Build configuration incorporating Vault and other sources
@@ -63,7 +64,7 @@ For more information, check the [complete documentation](https://docs.rs/config-
 ## Requirements
 
 - Rust 1.60 or higher
-- An accessible HashiCorp Vault server
+- An accessible HashiCorp Vault server or compatible like https://github.com/Tongsuo-Project/RustyVault
 
 ## License
 


### PR DESCRIPTION
Thanks for config-vault-rs, it was exactly what I had in mind and was about to start it on my own, but was happy to find it already as existing lib!

I am into very early testing, and first try with an alternative to HashiCorp Vault failed (https://github.com/Tongsuo-Project/RustyVault).

Found out that RustyVault currently only uses kv v1 without /data and so I just quickly modified config-vault-rs to support it.
https://github.com/Tongsuo-Project/RustyVault/issues/111

Improvements to my if/else code welcome ^^

~~untested: HashiCorp  kv v1~~
now tested succesfully with HashiCorp kv v1+v2 and RustyVault kv1